### PR TITLE
Feature/grammar like usebruno lang

### DIFF
--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -27,6 +27,7 @@
 		{"include": "#body-multipart-form-block"},
 		{"include": "#body-graphql-block"},
 		{"include": "#body-graphql-vars-block"},
+		{"include": "#body-sparql-block"},
 
 		{"include": "#assert-block"},
 		{"include": "#vars-block"},
@@ -309,6 +310,23 @@
 				}
 			},
 			"patterns": [{"include": "source.json"}]
+		},
+		"body-sparql-block": {
+			"name": "meta.body-sparql-block.bruno",
+			"begin": "^(body)(:)(sparql)\\s*\\{",
+			"end": "^\\}",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
+					"name": "keyword.bruno"
+				}
+			},
+			"patterns": [{"include": "source.sparql"}]
 		},
 		"vars-block": {
 			"name": "meta.vars-block.bruno",

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -361,11 +361,6 @@
 					"name": "keyword.bruno"
 				}
 			},
-			"endCaptures": {
-				"0": {
-					"name": "keyword.bruno"
-				}
-			},
 			"patterns": [
 				{
 					"include": "source.js"
@@ -381,11 +376,6 @@
 					"name": "keyword.bruno"
 				}
 			},
-			"endCaptures": {
-				"0": {
-					"name": "keyword.bruno"
-				}
-			},
 			"patterns": [
 				{
 					"include": "text.html.markdown"
@@ -394,12 +384,18 @@
 		},
 		"dictionary": {
 			"patterns": [{
-				"match": "^\\s*([^\\:]+)[\\:]\\s+([^\\n]+)\\s*$",
+				"match": "^\\s*(~?)([^\\:]+)(:)\\s*([^\\n]*)$",
 				"captures": {
 					"1": {
-						"name": "entity.name.tag.bruno"
+						"name": "keyword.operator.bruno"
 					},
 					"2": {
+						"name": "entity.name.tag.bruno"
+					},
+					"3": {
+						"name": "keyword.operator.bruno"
+					},
+					"4": {
 						"name": "string.bruno"
 					}
 				}

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -35,8 +35,7 @@
 		{"include": "#vars-req-block"},
 		{"include": "#vars-res-block"},
 
-		{"include": "#script-req-block"},
-		{"include": "#script-res-block"},
+		{"include": "#script-block"},
 		{"include": "#tests-block"},
 		{"include": "#docs-block"}
 	],
@@ -322,27 +321,18 @@
 			},
 			"patterns": [{"include": "#dictionary"}]
 		},
-		"script-req-block": {
-			"name": "meta.script-req-block.bruno",
-			"begin": "^script\\:pre-request\\s*\\{",
+		"script-block": {
+			"name": "meta.script-block.bruno",
+			"begin": "^(script)(:)(pre-request|post-response)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
-				}
-			},
-			"patterns": [
-				{
-					"include": "source.js"
-				}
-			]
-		},
-		"script-res-block": {
-			"name": "meta.script-res-block.bruno",
-			"begin": "^script\\:post-response\\s*\\{",
-			"end": "^\\}",
-			"beginCaptures": {
-				"0": {
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -32,8 +32,6 @@
 
 		{"include": "#assert-block"},
 		{"include": "#vars-block"},
-		{"include": "#vars-req-block"},
-		{"include": "#vars-res-block"},
 
 		{"include": "#script-block"},
 		{"include": "#tests-block"},
@@ -279,32 +277,16 @@
 		},
 		"vars-block": {
 			"name": "meta.vars-block.bruno",
-			"begin": "^vars\\s*\\{",
-			"end": "^\\}\\s*",
+			"begin": "^(vars)((:)(pre-request|post-response))?\\s*\\{",
+			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
-				}
-			},
-			"patterns": [{"include": "#dictionary"}]
-		},
-		"vars-req-block": {
-			"name": "meta.vars-req-block.bruno",
-			"begin": "^vars\\:pre-request\\s*\\{",
-			"end": "^\\}\\s*",
-			"beginCaptures": {
-				"0": {
-					"name": "keyword.bruno"
-				}
-			},
-			"patterns": [{"include": "#dictionary"}]
-		},
-		"vars-res-block": {
-			"name": "meta.vars-res-block.bruno",
-			"begin": "^vars\\:post-response\\s*\\{",
-			"end": "^\\}\\s*",
-			"beginCaptures": {
-				"0": {
+				},
+				"3": {
+					"name": "keyword.operator.bruno"
+				},
+				"4": {
 					"name": "keyword.bruno"
 				}
 			},

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -38,10 +38,10 @@
 	"repository": {
 		"meta-block": {
 			"name": "meta.meta-block.bruno",
-			"begin": "^meta\\s*\\{",
+			"begin": "^(meta)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -49,10 +49,10 @@
 		},
 		"get-block": {
 			"name": "meta.get-block.bruno",
-			"begin": "^get\\s*\\{",
+			"begin": "^(get)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -60,10 +60,10 @@
 		},
 		"post-block": {
 			"name": "meta.post-block.bruno",
-			"begin": "^post\\s*\\{",
+			"begin": "^(post)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -71,10 +71,10 @@
 		},
 		"put-block": {
 			"name": "meta.put-block.bruno",
-			"begin": "^put\\s*\\{",
+			"begin": "^(put)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -82,10 +82,10 @@
 		},
 		"delete-block": {
 			"name": "meta.delete-block.bruno",
-			"begin": "^delete\\s*\\{",
+			"begin": "^(delete)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -93,10 +93,10 @@
 		},
 		"options-block": {
 			"name": "meta.options-block.bruno",
-			"begin": "^options\\s*\\{",
+			"begin": "^(options)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -104,10 +104,10 @@
 		},
 		"head-block": {
 			"name": "meta.head-block.bruno",
-			"begin": "^head\\s*\\{",
+			"begin": "^(head)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -115,10 +115,10 @@
 		},
 		"trace-block": {
 			"name": "meta.trace-block.bruno",
-			"begin": "^trace\\s*\\{",
+			"begin": "^(trace)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -126,10 +126,10 @@
 		},
 		"connect-block": {
 			"name": "meta.connect-block.bruno",
-			"begin": "^connect\\s*\\{",
+			"begin": "^(connect)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -137,10 +137,10 @@
 		},
 		"query-block": {
 			"name": "meta.query-block.bruno",
-			"begin": "^query\\s*\\{",
+			"begin": "^(query)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -148,10 +148,10 @@
 		},
 		"headers-block": {
 			"name": "meta.headers-block.bruno",
-			"begin": "^headers\\s*\\{",
+			"begin": "^(headers)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -176,10 +176,10 @@
 		},
 		"body-block": {
 			"name": "meta.body-block.bruno",
-			"begin": "^body\\s*\\{",
+			"begin": "^(body)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -187,10 +187,16 @@
 		},
 		"body-json-block": {
 			"name": "meta.body-json-block.bruno",
-			"begin": "^body\\:json\\s*\\{",
+			"begin": "^(body)(:)(json)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -198,10 +204,16 @@
 		},
 		"body-text-block": {
 			"name": "meta.body-text-block.bruno",
-			"begin": "^body\\:text\\s*\\{",
+			"begin": "^(body)(:)(text)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -209,10 +221,16 @@
 		},
 		"body-xml-block": {
 			"name": "meta.body-xml-block.bruno",
-			"begin": "^body\\:xml\\s*\\{",
+			"begin": "^(body)(:)(xml)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -220,10 +238,16 @@
 		},
 		"body-form-urlencoded-block": {
 			"name": "meta.body-form-urlencoded-block.bruno",
-			"begin": "^body\\:form-urlencoded\\s*\\{",
+			"begin": "^(body)(:)(form-urlencoded)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -231,10 +255,16 @@
 		},
 		"body-multipart-form-block": {
 			"name": "meta.body-multipart-form-block.bruno",
-			"begin": "^body\\:multipart-form\\s*\\{",
+			"begin": "^(body)(:)(multipart-form)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -242,10 +272,16 @@
 		},
 		"body-graphql-block": {
 			"name": "meta.body-graphql-block.bruno",
-			"begin": "^body\\:graphql\\s*\\{",
+			"begin": "^(body)(:)(graphql)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -253,10 +289,22 @@
 		},
 		"body-graphql-vars-block": {
 			"name": "meta.body-graphql-vars-block.bruno",
-			"begin": "^body\\:graphql\\:vars\\s*\\{",
+			"begin": "^(body)(:)(graphql)(:)(vars)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
+					"name": "keyword.bruno"
+				},
+				"4": {
+					"name": "keyword.operator.bruno"
+				},
+				"5": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -281,10 +329,10 @@
 		},
 		"assert-block": {
 			"name": "meta.assert-block.bruno",
-			"begin": "^assert\\s*\\{",
+			"begin": "^(assert)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -313,10 +361,10 @@
 		},
 		"tests-block": {
 			"name": "meta.tests-block.bruno",
-			"begin": "^tests\\s*\\{",
+			"begin": "^(tests)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -328,10 +376,10 @@
 		},
 		"docs-block": {
 			"name": "meta.docs-block.bruno",
-			"begin": "^docs\\s*\\{",
+			"begin": "^(docs)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
-				"0": {
+				"1": {
 					"name": "keyword.bruno"
 				}
 			},
@@ -343,7 +391,7 @@
 		},
 		"dictionary": {
 			"patterns": [{
-				"match": "^\\s*(~?)([^\\:]+)(:)\\s*([^\\n]*)$",
+				"match": "^\\s*(~?)([^:]+)(:)\\s*([^\\n]*)$",
 				"captures": {
 					"1": {
 						"name": "keyword.operator.bruno"

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -3,8 +3,6 @@
 	"name": "bruno",
 	"scopeName": "source.bru",
 	"patterns": [
-		{"include": "#strings"},
-
 		{"include": "#meta-block"},
 
 		{"include": "#get-block"},
@@ -38,17 +36,6 @@
 		{"include": "#docs-block"}
 	],
 	"repository": {
-		"strings": {
-			"name": "string.quoted.double.bruno",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.bruno",
-					"match": "\\\\."
-				}
-			]
-		},
 		"meta-block": {
 			"name": "meta.meta-block.bruno",
 			"begin": "^meta\\s*\\{",

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -9,6 +9,7 @@
 		{"include": "#post-block"},
 		{"include": "#put-block"},
 		{"include": "#delete-block"},
+		{"include": "#patch-block"},
 		{"include": "#options-block"},
 		{"include": "#head-block"},
 		{"include": "#trace-block"},
@@ -84,6 +85,17 @@
 		"delete-block": {
 			"name": "meta.delete-block.bruno",
 			"begin": "^(delete)\\s*\\{",
+			"end": "^\\}",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.bruno"
+				}
+			},
+			"patterns": [{"include": "#dictionary"}]
+		},
+		"patch-block": {
+			"name": "meta.patch-block.bruno",
+			"begin": "^(patch)\\s*\\{",
 			"end": "^\\}",
 			"beginCaptures": {
 				"1": {

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -19,6 +19,8 @@
 		{"include": "#query-block"},
 		{"include": "#headers-block"},
 
+		{"include": "#auth-block"},
+
 		{"include": "#body-block"},
 		{"include": "#body-json-block"},
 		{"include": "#body-text-block"},
@@ -170,6 +172,23 @@
 				}
 			},
 			"patterns": [{"include": "#dictionary"}]
+		},
+		"auth-block": {
+			"name": "meta.auth.bruno",
+			"begin": "^(auth)(:)(awsv4|basic|bearer|digest|oauth2)\\s*\\{",
+			"end": "^\\}",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.bruno"
+				},
+				"2": {
+					"name": "keyword.operator.bruno"
+				},
+				"3": {
+					"name": "keyword.bruno"
+				}
+			},
+			"patterns": [{ "include": "#dictionary" }]
 		},
 		"body-block": {
 			"name": "meta.body-block.bruno",

--- a/packages/vscode/syntaxes/bruno.tmLanguage.json
+++ b/packages/vscode/syntaxes/bruno.tmLanguage.json
@@ -52,7 +52,7 @@
 		"meta-block": {
 			"name": "meta.meta-block.bruno",
 			"begin": "^meta\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -63,7 +63,7 @@
 		"get-block": {
 			"name": "meta.get-block.bruno",
 			"begin": "^get\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -74,7 +74,7 @@
 		"post-block": {
 			"name": "meta.post-block.bruno",
 			"begin": "^post\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -85,7 +85,7 @@
 		"put-block": {
 			"name": "meta.put-block.bruno",
 			"begin": "^put\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -96,7 +96,7 @@
 		"delete-block": {
 			"name": "meta.delete-block.bruno",
 			"begin": "^delete\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -107,7 +107,7 @@
 		"options-block": {
 			"name": "meta.options-block.bruno",
 			"begin": "^options\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -118,7 +118,7 @@
 		"head-block": {
 			"name": "meta.head-block.bruno",
 			"begin": "^head\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -129,7 +129,7 @@
 		"trace-block": {
 			"name": "meta.trace-block.bruno",
 			"begin": "^trace\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -140,7 +140,7 @@
 		"connect-block": {
 			"name": "meta.connect-block.bruno",
 			"begin": "^connect\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -151,7 +151,7 @@
 		"query-block": {
 			"name": "meta.query-block.bruno",
 			"begin": "^query\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -162,7 +162,7 @@
 		"headers-block": {
 			"name": "meta.headers-block.bruno",
 			"begin": "^headers\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -190,7 +190,7 @@
 		"body-block": {
 			"name": "meta.body-block.bruno",
 			"begin": "^body\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -201,7 +201,7 @@
 		"body-json-block": {
 			"name": "meta.body-json-block.bruno",
 			"begin": "^body\\:json\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -212,7 +212,7 @@
 		"body-text-block": {
 			"name": "meta.body-text-block.bruno",
 			"begin": "^body\\:text\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -223,7 +223,7 @@
 		"body-xml-block": {
 			"name": "meta.body-xml-block.bruno",
 			"begin": "^body\\:xml\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -234,7 +234,7 @@
 		"body-form-urlencoded-block": {
 			"name": "meta.body-form-urlencoded-block.bruno",
 			"begin": "^body\\:form-urlencoded\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -245,7 +245,7 @@
 		"body-multipart-form-block": {
 			"name": "meta.body-multipart-form-block.bruno",
 			"begin": "^body\\:multipart-form\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -256,7 +256,7 @@
 		"body-graphql-block": {
 			"name": "meta.body-graphql-block.bruno",
 			"begin": "^body\\:graphql\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -267,7 +267,7 @@
 		"body-graphql-vars-block": {
 			"name": "meta.body-graphql-vars-block.bruno",
 			"begin": "^body\\:graphql\\:vars\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"
@@ -295,7 +295,7 @@
 		"assert-block": {
 			"name": "meta.assert-block.bruno",
 			"begin": "^assert\\s*\\{",
-			"end": "^\\}\\s*",
+			"end": "^\\}",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.bruno"

--- a/test/syntax-highlighting-test.bru
+++ b/test/syntax-highlighting-test.bru
@@ -48,6 +48,27 @@ query {
   foo: 1
 }
 
+auth:awsv4 {
+  foo: 1
+}
+
+auth:basic {
+  foo: 1
+}
+
+auth:bearer {
+  foo: 1
+}
+
+auth:digest {
+  foo: 1
+}
+
+auth:oauth2 {
+  foo: 1
+}
+
+
 vars {
   foo: 1
 }

--- a/test/syntax-highlighting-test.bru
+++ b/test/syntax-highlighting-test.bru
@@ -1,0 +1,122 @@
+meta {
+  foo: 1
+  ~bar: a
+  :
+}
+
+get {
+  foo: 1
+}
+
+post {
+  foo: 1
+}
+
+put {
+  foo: 1
+}
+
+delete {
+  foo: 1
+}
+
+patch {
+  foo: 1
+}
+
+options {
+  foo: 1
+}
+
+head {
+  foo: 1
+}
+
+connect {
+  foo: 1
+}
+
+trace {
+  foo: 1
+}
+
+headers {
+  foo: 1
+}
+
+query {
+  foo: 1
+}
+
+vars {
+  foo: 1
+}
+
+vars:pre-request {
+  foo: 1
+}
+
+vars:post-response {
+  foo: 1
+}
+
+assert {
+  foo: 1
+}
+
+body {
+  {"foo": 1}
+}
+
+body:json {
+  {"foo": 1}
+}
+
+body:text {
+  foo: 1 _markdown???_
+}
+
+body:xml {
+  <foo bar="a">1</foo>
+}
+
+body:sparql {
+  SELECT *
+}
+
+body:graphql {
+  {
+    foo {
+      bar
+    }
+  }
+}
+
+body:graphql:vars {
+  {"foo": 1}
+}
+
+body:form-urlencoded {
+  foo: 1
+}
+
+body:multipart-form {
+  foo: 1
+}
+
+script:pre-request {
+  for (let word of ["Hello", "World"]) console.log("Word:", word)
+}
+
+script:post-response {
+  for (let word of ["Hello", "World"]) console.log("Word:", word)
+}
+
+tests {
+  for (let word of ["Hello", "World"]) console.log("Word:", word)
+}
+
+docs {
+  # H1
+  Hello *bruno*
+}


### PR DESCRIPTION
Updated TextMate grammar to match (mostly) the _@usebruno/lang_ grammar

- Add `auth:*` tag support (Resolves #8)
- Add `patch` and `body:sparql`  blocks
- Add syntax highlighting test file
- Some syntax highlighter styling adjustments

![image](https://github.com/usebruno/bruno-ide-extensions/assets/12899553/c139b516-d7f3-4b2e-a420-a9b344ddef88)

Edit:
Known differences to _@usebruno/lang_, that I am not planning to change right now (but I might in the future):

- Multiline Strings not supported by vscode syntax highlighting (#15)
- vars withour pre-request/post-response not supported by _@usebruno/lang_
   - Used for collection.bru, I suppose that this is intended, so I am not planning to remove that unless someone gives me a good reason 
- Blocks not starting at the begin of the line not supported by vscode syntax highlighting