### PR TITLE
feat: Add icon to bru files

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -43,6 +43,10 @@
         "extensions": [
           ".bru"
         ],
+        "icon": {
+          "light": "icon.png",
+          "dark": "icon.png"
+        },
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
Add the bruno icon to files so you can spot bru files faster in the explorer view and editor tab headers:
![image](https://github.com/usebruno/bruno-ide-extensions/assets/12899553/635495cc-680d-487d-9c2c-a8c8659a4f45)
